### PR TITLE
Updated BoardMain.hs in gtk2/examples/peg-solitaire

### DIFF
--- a/gtk2/examples/peg-solitaire/BoardMain.hs
+++ b/gtk2/examples/peg-solitaire/BoardMain.hs
@@ -5,6 +5,10 @@ import Graphics.UI.Gtk
 import Graphics.UI.Gtk.Layout.BackgroundContainer
 import Graphics.UI.Gtk.Board.BoardLink
 import GtkPegSolitaire
+import PegSolitaire
+import Graphics.UI.Gtk.Board.TiledBoard
+import Data.Maybe
+import Control.Monad
 
 main :: IO ()
 main = do


### PR DESCRIPTION
The following modules haven't been imported

```
import PegSolitaire
import Graphics.UI.Gtk.Board.TiledBoard
import Data.Maybe
import Control.Monad
```

Discussion can be found [here](https://github.com/keera-studios/gtk-helpers/issues/2).