### PR TITLE
Fix build with GHC 9

### DIFF
--- a/gtk2/src/Graphics/UI/Gtk/Extra/BuilderTH.hs
+++ b/gtk2/src/Graphics/UI/Gtk/Extra/BuilderTH.hs
@@ -57,8 +57,6 @@ gtkViewAccessor builderModule uiAccessor name kind = sequenceQ
                           )) []]
   ]
 
-  where castedAccess      = appE (varE (mkName "fromBuilder")) casting
-        casting           = varE (mkName ("castTo" ++ kind))
-        funcName          = mkName name
+  where funcName          = mkName name
         funcNameInBuilder = mkName $ builderModule ++ ('.' : name) 
         builderName       = mkName "b"


### PR DESCRIPTION
Hi there,

I think this is a nobrainer so I'm making this pull request
to remove some unused terms causing the build to fail with newer GHC:
```console
gtk2 $ cabal build
Build profile: -w ghc-9.0.2 -O1
In order, the following will be built (use -v for more details):
 - gtk-helpers-0.1.0 (lib) (file src/Graphics/UI/Gtk/Extra/BuilderTH.hs changed)
Preprocessing library for gtk-helpers-0.1.0..
Building library for gtk-helpers-0.1.0..
[23 of 23] Compiling Graphics.UI.Gtk.Extra.BuilderTH ( src/Graphics/UI/Gtk/Extra/BuilderTH.hs, /home/julm/src/haskell/gtk-helpers/gtk2/dist-newstyle/build/x86_64-linux/ghc-9.0.2/gtk-helpers-0.1.0/build/Graphics/UI/Gtk/Extra/BuilderTH.o, /home/julm/src/haskell/gtk-helpers/gtk2/dist-newstyle/build/x86_64-linux/ghc-9.0.2/gtk-helpers-0.1.0/build/Graphics/UI/Gtk/Extra/BuilderTH.dyn_o )

src/Graphics/UI/Gtk/Extra/BuilderTH.hs:60:29: error:
    • Ambiguous type variable ‘m0’ arising from a use of ‘appE’
      prevents the constraint ‘(Quote m0)’ from being solved.
      Relevant bindings include
        castedAccess :: m0 Exp
          (bound at src/Graphics/UI/Gtk/Extra/BuilderTH.hs:60:9)
        casting :: m0 Exp
          (bound at src/Graphics/UI/Gtk/Extra/BuilderTH.hs:61:9)
      Probable fix: use a type annotation to specify what ‘m0’ should be.
      These potential instances exist:
        instance Quote IO -- Defined in ‘Language.Haskell.TH.Syntax’
        instance Quote Q -- Defined in ‘Language.Haskell.TH.Syntax’
    • In the expression: appE (varE (mkName "fromBuilder")) casting
      In an equation for ‘castedAccess’:
          castedAccess = appE (varE (mkName "fromBuilder")) casting
      In an equation for ‘gtkViewAccessor’:
          gtkViewAccessor builderModule uiAccessor name kind
            = sequenceQ
                [sigD
                   funcName
                   (appT
                      (appT arrowT (conT (mkName "View")))
                      (appT (conT (mkName "IO")) (conT (mkName kind)))),
                 funD
                   funcName
                   [clause
                      ...
                      (normalB
                         (appE
                            (varE funcNameInBuilder)
                            (appE (varE (mkName uiAccessor)) (varE builderName))))
                      []]]
            where
                castedAccess = appE (varE (mkName "fromBuilder")) casting
                casting = varE (mkName ("castTo" ++ kind))
                funcName = mkName name
                funcNameInBuilder = mkName $ builderModule ++ ('.' : name)
                ....
   |
60 |   where castedAccess      = appE (varE (mkName "fromBuilder")) casting
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Graphics/UI/Gtk/Extra/BuilderTH.hs:61:29: error:
    • Ambiguous type variable ‘m0’ arising from a use of ‘varE’
      prevents the constraint ‘(Quote m0)’ from being solved.
      Relevant bindings include
        casting :: m0 Exp
          (bound at src/Graphics/UI/Gtk/Extra/BuilderTH.hs:61:9)
      Probable fix: use a type annotation to specify what ‘m0’ should be.
      These potential instances exist:
        instance Quote IO -- Defined in ‘Language.Haskell.TH.Syntax’
        instance Quote Q -- Defined in ‘Language.Haskell.TH.Syntax’
    • In the expression: varE (mkName ("castTo" ++ kind))
      In an equation for ‘casting’:
          casting = varE (mkName ("castTo" ++ kind))
      In an equation for ‘gtkViewAccessor’:
          gtkViewAccessor builderModule uiAccessor name kind
            = sequenceQ
                [sigD
                   funcName
                   (appT
                      (appT arrowT (conT (mkName "View")))
                      (appT (conT (mkName "IO")) (conT (mkName kind)))),
                 funD
                   funcName
                   [clause
                      ...
                      (normalB
                         (appE
                            (varE funcNameInBuilder)
                            (appE (varE (mkName uiAccessor)) (varE builderName))))
                      []]]
            where
                castedAccess = appE (varE (mkName "fromBuilder")) casting
                casting = varE (mkName ("castTo" ++ kind))
                funcName = mkName name
                funcNameInBuilder = mkName $ builderModule ++ ('.' : name)
                ....
   |
61 |         casting           = varE (mkName ("castTo" ++ kind))
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Thanks for maintaining this library.